### PR TITLE
Fixing memoery leak(https://github.com/jquery/jquery-mobile/issues/5156)

### DIFF
--- a/js/jquery.mobile.navigation.js
+++ b/js/jquery.mobile.navigation.js
@@ -600,10 +600,11 @@ define( [
 
 	/* exposed $.mobile methods */
 
+    var animationEndEvent = "WebKitTransitionEvent" in window ? "webkitAnimationEnd" : "animationend";
 	//animation complete callback
 	$.fn.animationComplete = function( callback ) {
 		if ( $.support.cssTransitions ) {
-			return $( this ).one( 'webkitAnimationEnd animationend', callback );
+			return $( this ).one( animationEndEvent, callback );
 		}
 		else{
 			// defer execution for consistency between webkit/non webkit


### PR DESCRIPTION
The memory leak causes click on almost all elements on original page will reopen dialog again after opening dialog once.
